### PR TITLE
updated styles for Link

### DIFF
--- a/src/components/Link/styles.ts
+++ b/src/components/Link/styles.ts
@@ -3,7 +3,7 @@ import { Link as RRLink } from 'react-router-dom'
 
 const LinkBaseStyles = css`
   text-decoration: none;
-  color: #383838;
+  color: ${props => props.theme.color.foregroundPrimary};
   border-bottom: 1px solid #383838;
   padding-bottom: 2px;
 


### PR DESCRIPTION
## Summary of Reasons

The Link font color wasn't updated to work with the dynamic background color from the changing themes.

## Changes

- updated styles for the Link component to use font color from theme 

## Notes
