### PR TITLE
Updates/text size n more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.2] = 2019-06-30
+## [0.0.3] - 2019-07-01
+
+### Changed
+
+- global styles
+- default Text font size
+- major change to theme button, now using `react-switch`
+
+### Added
+
+- `react-switch` library
+
+## [0.0.2] - 2019-06-30
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.0",
     "react-spring": "^8.0.20",
+    "react-switch": "^5.0.0",
     "react-syntax-highlighter": "^10.2.1",
     "styled-components": "^4.3.2",
     "typescript": "^3.5.2"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,15 @@ import { createGlobalStyle } from 'styled-components'
 import { ThemeProvider } from 'styled-components'
 
 import { themeDay, themeNight } from 'shared/theme'
+import { base } from 'shared/utils'
 
 import ApplicationContext from 'shared/context/Application'
 import Router from 'containers/Router'
 
 const GlobalStyle = createGlobalStyle`
   body {
-    background: ${props => (props.theme === 'day' ? '#e8e8e8' : '#383838')}
+    background: ${props => (props.theme === 'day' ? '#e8e8e8' : '#383838')};
+    font-size: ${base}px;
   }
 `
 

--- a/src/components/Link/styles.ts
+++ b/src/components/Link/styles.ts
@@ -6,6 +6,7 @@ const LinkBaseStyles = css`
   color: ${({ theme }) => theme.foregroundPrimary};
   border-bottom: 1px solid #383838;
   padding-bottom: 2px;
+  font-size: ${({ theme }) => theme.typography.size.medium};
 
   &:visited {
     color: palevioletred;

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -43,7 +43,7 @@ const Text = ({ type, children, className, size }: TextProps) => {
 Text.defaultProps = {
   type: 'paragraph',
   children: 'missing text',
-  size: 'regular'
+  size: 'medium'
 }
 
 export default Text

--- a/src/components/Text/styles.ts
+++ b/src/components/Text/styles.ts
@@ -1,13 +1,15 @@
 import styled from 'styled-components'
 import * as R from 'ramda'
 
+import { remCalc } from 'shared/utils'
+
 import { TextProps } from './Text'
 
 const Span = styled.span<TextProps>`
   color: ${props => props.theme.color.foregroundPrimary};
 
   font-size: ${props =>
-    R.pathOr('14px', ['theme', 'typography', 'size', props.size], props)};
+    R.pathOr(remCalc(16), ['theme', 'typography', 'size', props.size], props)};
 `
 
 const Paragraph = styled.p<TextProps>`

--- a/src/containers/Header/Header.tsx
+++ b/src/containers/Header/Header.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { RouteComponentProps, withRouter } from 'react-router-dom'
+import Switch from 'react-switch'
 
-import Button from 'components/Button'
 import Icon from 'components/Icon'
 import Layout from 'components/Layout'
 import NavBar from 'components/NavBar'
 import withApplicationContext from 'shared/HoC/withApplicationContext'
 import { ApplicationContextState } from 'shared/context/Application'
-import { themeDay } from 'shared/theme'
+
+import * as S from './styles'
 
 export interface HeaderProps extends RouteComponentProps {
   applicationContext: ApplicationContextState
@@ -18,6 +19,15 @@ const Header = ({
   applicationContext: { theme, setTheme }
 }: HeaderProps) => {
   const { pathname } = location
+
+  // @checked - future state, not current
+  const handleOnChange = (checked: boolean) => {
+    if (!checked) {
+      return setTheme('day')
+    }
+
+    return setTheme('night')
+  }
 
   return (
     <Layout>
@@ -45,15 +55,23 @@ const Header = ({
           ]}
         />
 
-        <Button
-          onClick={() => setTheme(theme === 'day' ? 'night' : 'day')}
-          disabled={false}
-        >
-          <Icon
-            type={theme === 'day' ? 'Moon' : 'Sun'}
-            color={theme === 'day' ? '#383838' : themeDay.color.base.amber}
-          />
-        </Button>
+        <Switch
+          onChange={handleOnChange}
+          checked={theme === 'night'}
+          checkedIcon={
+            <S.IconWrap>
+              <Icon type='Moon' />
+            </S.IconWrap>
+          }
+          uncheckedIcon={
+            <S.IconWrap>
+              <Icon type='Sun' color='#f8f8f8' />
+            </S.IconWrap>
+          }
+          height={35}
+          width={75}
+          onColor='#ffc107'
+        />
       </Layout.Flex>
     </Layout>
   )

--- a/src/containers/Header/styles.ts
+++ b/src/containers/Header/styles.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+const IconWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`
+
+export { IconWrap }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,0 +1,5 @@
+const base = 16
+
+const remCalc = (value: number) => `${value / base}rem`
+
+export { base, remCalc }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10140,6 +10140,13 @@ react-spring@^8.0.20:
     "@babel/runtime" "^7.3.1"
     prop-types "^15.5.8"
 
+react-switch@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-switch/-/react-switch-5.0.0.tgz#ecbb666f8789cb8138b3ba1160bc3745390ab502"
+  integrity sha512-+zxY9xj9dMc8Y4gv/kkqQrirfEiIQ+SlQfJDW1Wi81L3xoh1fcbBYyJyh0TnhM/U/b6HxuBmkmU4Ooxgtuoavw==
+  dependencies:
+    prop-types "^15.6.2"
+
 react-syntax-highlighter@^10.2.1:
   version "10.2.1"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-10.2.1.tgz#a30bf8e131c29e714a8e781ecadbace329da1530"


### PR DESCRIPTION
## Summary of Reasons

I've finally updated the theme button. It used to be an icon that wasn't easily parsed as button by the user. I've installed `react-switch` and now it's a pretty obvious toggle switch.

I've also updated the default prop for `Text`, increasing the font-size.

## Changes

- updated label styles
- removed old icon button for theme, swapped in `react-switch`
- updated default prop for `Text`'s font-size

## Notes
